### PR TITLE
Refactored the code of the load_file methods to not check if document was allocated.

### DIFF
--- a/src/controldata.c
+++ b/src/controldata.c
@@ -364,17 +364,9 @@ DBOOL afs_control_data_load_file(afs_control_data * control_data, const char * f
     }
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
-    
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
 
-        return DFALSE;
-    }
-    
     DBOOL return_value = afs_control_data_load_xml(control_data, document);
-    
+
     fclose(fp_load);
     mxmlDelete(document);
 

--- a/src/controlframe/boxingformat.c
+++ b/src/controlframe/boxingformat.c
@@ -419,14 +419,6 @@ DBOOL afs_boxing_format_load_config_file(afs_boxing_format* boxing_format, const
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
 
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
-
-        return DFALSE;
-    }
-
     DBOOL return_value = afs_boxing_format_load_xml(boxing_format, document);
 
     fclose(fp_load);

--- a/src/technicalmetadata.c
+++ b/src/technicalmetadata.c
@@ -373,17 +373,9 @@ DBOOL afs_technical_metadata_load_file(afs_technical_metadata * technical_metada
     }
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
-    
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
 
-        return DFALSE;
-    }
-    
     DBOOL return_value = afs_technical_metadata_load_xml(technical_metadata, document);
-    
+
     fclose(fp_load);
     mxmlDelete(document);
 

--- a/src/toc/previewlayoutdefinition.c
+++ b/src/toc/previewlayoutdefinition.c
@@ -597,17 +597,9 @@ DBOOL afs_toc_preview_layout_definition_load_file(afs_toc_preview_layout_definit
     }
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
-    
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
 
-        return DFALSE;
-    }
-    
     DBOOL return_value = afs_toc_preview_layout_definition_load_xml(toc_preview_layout_definition, document);
-    
+
     fclose(fp_load);
     mxmlDelete(document);
 

--- a/src/toc/previewlayoutdefinitions.c
+++ b/src/toc/previewlayoutdefinitions.c
@@ -727,14 +727,6 @@ DBOOL afs_toc_preview_layout_definitions_load_file(afs_toc_preview_layout_defini
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
 
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
-
-        return DFALSE;
-    }
-
     DBOOL return_value = afs_toc_preview_layout_definitions_load_xml(toc_preview_layout_definitions, document);
 
     fclose(fp_load);

--- a/src/toc/previewsection.c
+++ b/src/toc/previewsection.c
@@ -483,14 +483,6 @@ DBOOL afs_toc_preview_section_load_file(afs_toc_preview_section * toc_preview_se
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
 
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
-
-        return DFALSE;
-    }
-
     DBOOL return_value = afs_toc_preview_section_load_xml(toc_preview_section, document);
 
     fclose(fp_load);

--- a/src/toc/previewsections.c
+++ b/src/toc/previewsections.c
@@ -560,14 +560,6 @@ DBOOL afs_toc_preview_sections_load_file(afs_toc_preview_sections * toc_preview_
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
 
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
-
-        return DFALSE;
-    }
-
     DBOOL return_value = afs_toc_preview_sections_load_xml(toc_preview_sections, document);
 
     fclose(fp_load);

--- a/src/tocdata.c
+++ b/src/tocdata.c
@@ -1195,17 +1195,9 @@ DBOOL afs_toc_data_load_file(afs_toc_data * toc_data, const char * file_name)
     }
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
-    
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
 
-        return DFALSE;
-    }
-    
     DBOOL return_value = afs_toc_data_load_xml(toc_data, document);
-    
+
     fclose(fp_load);
     mxmlDelete(document);
 

--- a/src/tocdatafilemetadata.c
+++ b/src/tocdatafilemetadata.c
@@ -622,17 +622,9 @@ DBOOL afs_toc_data_file_metadata_load_file(afs_toc_data_file_metadata * toc_data
     }
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
-    
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
 
-        return DFALSE;
-    }
-    
     DBOOL return_value = afs_toc_data_file_metadata_load_xml(toc_data_file_metadata, document);
-    
+
     fclose(fp_load);
     mxmlDelete(document);
 

--- a/src/tocdatafilemetadatasource.c
+++ b/src/tocdatafilemetadatasource.c
@@ -479,14 +479,6 @@ DBOOL afs_toc_data_file_metadata_source_load_file(afs_toc_data_file_metadata_sou
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
 
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
-
-        return DFALSE;
-    }
-
     DBOOL return_value = afs_toc_data_file_metadata_source_load_xml(toc_data_file_metadata_source, document);
 
     fclose(fp_load);

--- a/src/tocdatareel.c
+++ b/src/tocdatareel.c
@@ -1089,17 +1089,9 @@ DBOOL afs_toc_data_reel_load_file(afs_toc_data_reel * toc_data_reel, const char 
     }
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
-    
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
 
-        return DFALSE;
-    }
-    
     DBOOL return_value = afs_toc_data_reel_load_xml(toc_data_reel, document);
-    
+
     fclose(fp_load);
     mxmlDelete(document);
 

--- a/src/tocdatareels.c
+++ b/src/tocdatareels.c
@@ -516,17 +516,9 @@ DBOOL afs_toc_data_reels_load_file(afs_toc_data_reels * toc_data_reels, const ch
     }
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
-    
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
 
-        return DFALSE;
-    }
-    
     DBOOL return_value = afs_toc_data_reels_load_xml(toc_data_reels, document);
-    
+
     fclose(fp_load);
     mxmlDelete(document);
 

--- a/src/tocfile.c
+++ b/src/tocfile.c
@@ -692,14 +692,6 @@ DBOOL afs_toc_file_load_file(afs_toc_file * toc_data_file, const char * file_nam
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
 
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
-
-        return DFALSE;
-    }
-
     DBOOL return_value = afs_toc_file_load_xml(toc_data_file, document);
 
     fclose(fp_load);

--- a/src/tocfilepreview.c
+++ b/src/tocfilepreview.c
@@ -710,16 +710,8 @@ DBOOL afs_toc_file_preview_load_file(afs_toc_file_preview * toc_file_preview, co
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
 
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
-
-        return DFALSE;
-    }
-    
     DBOOL return_value = afs_toc_file_preview_load_xml(toc_file_preview, document);
-    
+
     fclose(fp_load);
     mxmlDelete(document);
 

--- a/src/tocfilepreviewpage.c
+++ b/src/tocfilepreviewpage.c
@@ -587,16 +587,8 @@ DBOOL afs_toc_file_preview_page_load_file(afs_toc_file_preview_page * toc_file_p
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
 
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
-
-        return DFALSE;
-    }
-
     DBOOL return_value = afs_toc_file_preview_page_load_xml(toc_file_preview_page, document);
-    
+
     fclose(fp_load);
     mxmlDelete(document);
 

--- a/src/tocfiles.c
+++ b/src/tocfiles.c
@@ -790,17 +790,9 @@ DBOOL afs_toc_files_load_file(afs_toc_files * toc_files, const char * file_name)
     }
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
-    
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
 
-        return DFALSE;
-    }
-    
     DBOOL return_value = afs_toc_files_load_xml(toc_files, document);
-    
+
     fclose(fp_load);
     mxmlDelete(document);
 

--- a/src/tocmetadata.c
+++ b/src/tocmetadata.c
@@ -588,17 +588,9 @@ DBOOL afs_toc_metadata_load_file(afs_toc_metadata * toc_metadata, const char * f
     }
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
-    
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
 
-        return DFALSE;
-    }
-    
     DBOOL return_value = afs_toc_metadata_load_xml(toc_metadata, document);
-    
+
     fclose(fp_load);
     mxmlDelete(document);
 

--- a/src/tocmetadatasource.c
+++ b/src/tocmetadatasource.c
@@ -923,14 +923,6 @@ DBOOL afs_toc_metadata_source_load_file(afs_toc_metadata_source * toc_metadata_s
 
     mxml_node_t * document = mxmlLoadFile(NULL, fp_load, MXML_OPAQUE_CALLBACK);
 
-    if (document == NULL)
-    {
-        fclose(fp_load);
-        mxmlDelete(document);
-
-        return DFALSE;
-    }
-
     DBOOL return_value = afs_toc_metadata_source_load_xml(toc_metadata_source, document);
 
     fclose(fp_load);


### PR DESCRIPTION
This pull request removes the checks to test if  `document == NULL` and the unnecessary call to `mxmlDelete(document)`. The various `_xml(` methods already check if `document` is null and will return false when this happens. 